### PR TITLE
4 bug able to make payment types without information

### DIFF
--- a/components/form-elements/input.js
+++ b/components/form-elements/input.js
@@ -1,4 +1,4 @@
-export function Input({ id, type="text", placeholder="", refEl=undefined, label=undefined, onChangeEvent, addlClass="", children }) {
+export function Input({ id, type="text", placeholder="", refEl=undefined, label=undefined, onChangeEvent, addlClass="", required, children }) {
   return (
     <div className={`field ${addlClass}`}>
       {label && <label className="label">{label}</label>}
@@ -10,6 +10,7 @@ export function Input({ id, type="text", placeholder="", refEl=undefined, label=
           type={type}
           ref={refEl}
           onChange={onChangeEvent}
+          required={required}
         ></input>
       </div>
       {children}

--- a/components/payments/payment-modal.js
+++ b/components/payments/payment-modal.js
@@ -6,36 +6,46 @@ export default function AddPaymentModal({ showModal, setShowModal, addNewPayment
   const merchantNameInput = useRef()
   const acctNumInput = useRef()
   const expirationDate = useRef()
+  const formRef = useRef()
+
+  const handleSubmit = () => {
+    if (!formRef.current.reportValidity()) return
+    addNewPayment({
+      account_number: acctNumInput.current.value,
+      merchant_name: merchantNameInput.current.value,
+      expiration_date: expirationDate.current.value
+    })
+  }
+
   return (
     <Modal showModal={showModal} setShowModal={setShowModal} title="Add New Payment Method">
-      <>
+      <form ref={formRef}>
         <Input
           id="merchantName"
           type="text"
           label="Merchant Name"
           refEl={merchantNameInput}
+          required={true}
         />
         <Input
           id="accNum"
           type="text"
           label="Account Number"
           refEl={acctNumInput}
+          required={true}
         />
         <Input
           id="expirationDate"
           type="date"
           label="Expiration Date"
           refEl={expirationDate}
+          required={true}
         />
-      </>
+      </form>
       <>
         <button
           className="button is-success"
-          onClick={() => addNewPayment({
-            account_number: acctNumInput.current.value,
-            merchant_name: merchantNameInput.current.value,
-            expiration_date: expirationDate.current.value
-          })}
+          onClick={handleSubmit}
         >Add Payment Method</button>
         <button className="button" onClick={() => setShowModal(false)}>Cancel</button>
       </>


### PR DESCRIPTION
Added a 'required' attribute and a submit function that will check the form for field validity. If the form has missing input, then a popup will appear in the UI requesting to fill out the field before submitting.

## CHANGES

- formRef to hold the state
- handleSubmit to read and check the validity of the form 
- ```required``` attribute to Input element

## TESTING

- [x] Npm run dev on client repo
- [x] Run debugger in client
- [x] Open the browser at localhost:3000
- [x] Log in
- [x] navigate to Payment Methods
- [x] create a payment method
- [x] try to create a payment method with blank fields

## RELATED ISSUES
  
Fixes https://github.com/NSS-Day-Cohort-79/Bangazon-client-hrmjnv/issues/4
