### PR TITLE
42 bug cant rate products

### DIFF
--- a/components/rating/detail.js
+++ b/components/rating/detail.js
@@ -3,18 +3,10 @@ import { rateProduct } from '../../data/products'
 import { RatingsContainer } from './container'
 import { Header } from './header'
 
-export function Ratings({ average_rating, refresh, ratings = [], number_purchased, likes = [] }) {
-  const [productId, setProductId] = useState(0)
+export function Ratings({ average_rating, refresh, ratings = [], number_purchased, likes = [], productId }) {
   const saveRating = (newRating) => {
     rateProduct(productId, newRating).then(refresh)
-
   }
-
-  useEffect(() => {
-    if (ratings.length) {
-      setProductId(ratings[0].product)
-    }
-  }, [ratings])
 
   return (
     <div className="tile is-ancestor is-flex-wrap-wrap">

--- a/components/rating/form.js
+++ b/components/rating/form.js
@@ -6,9 +6,8 @@ export default function RatingForm({ saveRating }) {
   const [comment, setComment] = useState("")
   
   const submitRating = () => {
-    const outOf5 = rating/20
     saveRating({
-      score: outOf5,
+      score: rating,
       review: comment
     })
   }

--- a/data/products.js
+++ b/data/products.js
@@ -60,7 +60,7 @@ export function deleteProduct(id) {
 }
 
 export function rateProduct(productId, rating) {
-  return fetchWithResponse(`products/${productId}/rate-product`, {
+  return fetchWithResponse(`products/${productId}/rate`, {
     method: 'POST',
     headers: {
       Authorization: `Token ${localStorage.getItem('token')}`,

--- a/pages/products/[id]/index.js
+++ b/pages/products/[id]/index.js
@@ -39,7 +39,7 @@ export default function ProductDetail() {
         <Detail product={product} like={like} unlike={unlike}/>
         <Ratings
           refresh={refresh}
-          number_purchased={product.number_purchased}
+          number_purchased={product.number_sold}
           ratings={product.ratings}
           average_rating={product.average_rating}
           likes={product.likes}

--- a/pages/products/[id]/index.js
+++ b/pages/products/[id]/index.js
@@ -43,6 +43,7 @@ export default function ProductDetail() {
           ratings={product.ratings}
           average_rating={product.average_rating}
           likes={product.likes}
+          productId={id}
         />
       </div>
     </div>


### PR DESCRIPTION
Fixes the product rating feature which was broken due to multiple issues in the ratings components and data layer.

This requires PR 55 from the api to test.
https://github.com/NSS-Day-Cohort-79/Bangazon-api-hrmjnv/pull/55 

## Changes

- Fixed `Ratings` component to accept `productId` as a prop instead of pulling it from ratings (which could be empty)
- Fixed `/product/:id/rate` fetch URL that had an extra `-product` string in the path
- Fixed rating form that was incorrectly dividing the rating value by 20 before sending
- Fixed product detail page to display `number_sold` instead of `number_purchased`

## Testing

Navigate to any product detail page and submit a star rating.

- [x] Run `npm run dev`
- [x] Go to a product detail page
- [x] Submit a rating using the star selector
- [x] Confirm the rating is saved and displayed correctly
- [x] Confirm the sell count displays correctly on the product detail page

## Related Issues

- Fixes #42
