### PR TITLE
44 bug delete order button doesnt clear cart

### DIFF
--- a/data/orders.js
+++ b/data/orders.js
@@ -26,3 +26,12 @@ export function completeCurrentOrder(orderId, payment_type) {
     body: JSON.stringify({payment_type})
   })
 }
+
+export function deleteCurrentOrder() {
+  return fetchWithResponse(`profile/cart`, {
+    method: 'DELETE',
+    headers: {
+      Authorization: `Token ${localStorage.getItem('token')}`
+    }
+  })
+}

--- a/pages/cart.js
+++ b/pages/cart.js
@@ -1,48 +1,54 @@
-import { useRouter } from 'next/router'
-import { useEffect, useState } from 'react'
-import CardLayout from '../components/card-layout'
-import Layout from '../components/layout'
-import Navbar from '../components/navbar'
-import CartDetail from '../components/order/detail'
-import CompleteFormModal from '../components/order/form-modal'
-import { completeCurrentOrder, deleteCurrentOrder, getCart } from '../data/orders'
-import { getPaymentTypes } from '../data/payment-types'
-import { removeProductFromOrder } from '../data/products'
+import { useRouter } from "next/router";
+import { useEffect, useState } from "react";
+import CardLayout from "../components/card-layout";
+import Layout from "../components/layout";
+import Navbar from "../components/navbar";
+import CartDetail from "../components/order/detail";
+import CompleteFormModal from "../components/order/form-modal";
+import {
+  completeCurrentOrder,
+  deleteCurrentOrder,
+  getCart,
+} from "../data/orders";
+import { getPaymentTypes } from "../data/payment-types";
+import { removeProductFromOrder } from "../data/products";
 
 export default function Cart() {
-  const [cart, setCart] = useState({})
-  const [paymentTypes, setPaymentTypes] = useState([])
-  const [showCompleteForm, setShowCompleteForm] = useState(false)
-  const router = useRouter()
+  const [cart, setCart] = useState({});
+  const [paymentTypes, setPaymentTypes] = useState([]);
+  const [showCompleteForm, setShowCompleteForm] = useState(false);
+  const router = useRouter();
 
   const refresh = () => {
-    getCart().then(cartData => {
+    getCart().then((cartData) => {
       if (cartData) {
-        setCart(cartData)
+        setCart(cartData);
       }
-    })
-  }
+    });
+  };
 
   useEffect(() => {
-    refresh()
-    getPaymentTypes().then(paymentData => {
+    refresh();
+    getPaymentTypes().then((paymentData) => {
       if (paymentData) {
-        setPaymentTypes(paymentData)
+        setPaymentTypes(paymentData);
       }
-    })
-  }, [])
+    });
+  }, []);
 
   const completeOrder = (paymentTypeId) => {
-    completeCurrentOrder(cart.id, paymentTypeId).then(() => router.push('/my-orders'))
-  }
+    completeCurrentOrder(cart.id, paymentTypeId).then(() =>
+      router.push("/my-orders"),
+    );
+  };
 
   const deleteOrder = () => {
-    deleteCurrentOrder().then(() => router.push('/products'))
-  }
+    deleteCurrentOrder().then(() => router.push("/products"));
+  };
 
   const removeProduct = (productId) => {
-    removeProductFromOrder(productId).then(refresh)
-  }
+    removeProductFromOrder(productId).then(refresh);
+  };
 
   return (
     <>
@@ -52,15 +58,29 @@ export default function Cart() {
         paymentTypes={paymentTypes}
         completeOrder={completeOrder}
       />
-      <CardLayout title="Your Current Order">
-        <CartDetail cart={cart} removeProduct={removeProduct} />
-        <>
-          <a className="card-footer-item" onClick={() => setShowCompleteForm(true)}>Complete Order</a>
-          <a className="card-footer-item" onClick={deleteOrder}>Delete Order</a>
-        </>
-      </CardLayout>
+      {cart?.id ? (
+        <CardLayout title="Your Current Order">
+          <CartDetail cart={cart} removeProduct={removeProduct} />
+          <>
+            <a
+              className="card-footer-item"
+              onClick={() => setShowCompleteForm(true)}
+            >
+              Complete Order
+            </a>
+            <a className="card-footer-item" onClick={deleteOrder}>
+              Delete Order
+            </a>
+          </>
+        </CardLayout>
+      ) : (
+        <CardLayout title="Your Cart is Empty">
+          <CartDetail cart={cart} removeProduct={removeProduct} />
+          <></>
+        </CardLayout>
+      )}
     </>
-  )
+  );
 }
 
 Cart.getLayout = function getLayout(page) {
@@ -69,5 +89,5 @@ Cart.getLayout = function getLayout(page) {
       <Navbar />
       <section className="container">{page}</section>
     </Layout>
-  )
-}
+  );
+};

--- a/pages/cart.js
+++ b/pages/cart.js
@@ -5,7 +5,7 @@ import Layout from '../components/layout'
 import Navbar from '../components/navbar'
 import CartDetail from '../components/order/detail'
 import CompleteFormModal from '../components/order/form-modal'
-import { completeCurrentOrder, getCart } from '../data/orders'
+import { completeCurrentOrder, deleteCurrentOrder, getCart } from '../data/orders'
 import { getPaymentTypes } from '../data/payment-types'
 import { removeProductFromOrder } from '../data/products'
 
@@ -36,6 +36,10 @@ export default function Cart() {
     completeCurrentOrder(cart.id, paymentTypeId).then(() => router.push('/my-orders'))
   }
 
+  const deleteOrder = () => {
+    deleteCurrentOrder().then(() => router.push('/products'))
+  }
+
   const removeProduct = (productId) => {
     removeProductFromOrder(productId).then(refresh)
   }
@@ -52,7 +56,7 @@ export default function Cart() {
         <CartDetail cart={cart} removeProduct={removeProduct} />
         <>
           <a className="card-footer-item" onClick={() => setShowCompleteForm(true)}>Complete Order</a>
-          <a className="card-footer-item">Delete Order</a>
+          <a className="card-footer-item" onClick={deleteOrder}>Delete Order</a>
         </>
       </CardLayout>
     </>


### PR DESCRIPTION
Fixes bug where the Delete Order button on the cart page had no functionality and did not clear the cart.

## Changes

- Added `deleteCurrentOrder` function to [data/orders.js](data/orders.js) that sends a DELETE request to `profile/cart`
- Added `deleteOrder` handler to [pages/cart.js](pages/cart.js) that calls `deleteCurrentOrder` and redirects to `/products`
- Wired the Delete Order button's `onClick` to the new `deleteOrder` handler
- Added conditional rendering in [pages/cart.js](pages/cart.js) so that when the cart is empty, action buttons are hidden and a "Your Cart is Empty" message is shown — preventing bad requests on an empty cart

## Testing

- [x] Run `npm run dev`
- [x] Log in and add a product to your cart
- [x] Navigate to `/cart` and click **Delete Order**
- [x] Verify you are redirected to `/products` and the cart is cleared
- [x] Navigate back to `/cart` with no open order and verify the empty cart message is shown with no action buttons

## Related Issues

- Fixes #44
