### PR TITLE
67 categories are not populating in the filter correctly

### DIFF
--- a/components/filter.js
+++ b/components/filter.js
@@ -15,7 +15,7 @@ export default function Filter({ productCount, onSearch, locations }) {
 
   const [showFilters, setShowFilters] = useState(false)
   const [query, setQuery] = useState('')
-  const [categories, setCategories] = useState([{id: 1, name: 'Apples'}, {id: 2, name: 'Oranges'}, {id: 3, name: 'Lemons'}])
+  const [categories, setCategories] = useState([])
   const [direction, setDirection] = useState('asc')
   const clear = () => {
     for (let ref in refEls) {
@@ -52,6 +52,14 @@ export default function Filter({ productCount, onSearch, locations }) {
       label: 'desc'
     },
   ]
+
+  useEffect(() => {
+    getCategories().then(categoryData => {
+      if (categoryData) {
+        setCategories(categoryData)
+      }
+    })
+  }, [])
 
   useEffect(() => {
     if (query) {
@@ -110,7 +118,7 @@ export default function Filter({ productCount, onSearch, locations }) {
               >
                 <span>Filter Products</span>
                 <span className="icon is-small">
-                <i className="fas fa-filter"></i>
+                  <i className="fas fa-filter"></i>
                 </span>
               </button>
             </div>

--- a/data/products.js
+++ b/data/products.js
@@ -15,7 +15,7 @@ export function getProducts(query = undefined) {
 }
 
 export function getCategories() {
-  return fetchWithResponse("categories", {
+  return fetchWithResponse('productcategories', {
     headers: {
       Authorization: `Token ${localStorage.getItem("token")}`,
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -935,6 +935,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1806,6 +1807,7 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -2005,6 +2007,7 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -3466,6 +3469,7 @@
       "resolved": "https://registry.npmjs.org/next/-/next-16.2.3.tgz",
       "integrity": "sha512-9V3zV4oZFza3PVev5/poB9g0dEafVcgNyQ8eTRop8GvxZjV2G15FC5ARuG1eFD42QgeYkzJBJzHghNP8Ad9xtA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@next/env": "16.2.3",
         "@swc/helpers": "0.5.15",
@@ -3919,6 +3923,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -3931,6 +3936,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"

--- a/pages/products/index.js
+++ b/pages/products/index.js
@@ -3,40 +3,63 @@ import Filter from '../../components/filter'
 import Layout from '../../components/layout'
 import Navbar from '../../components/navbar'
 import { ProductCard } from '../../components/product/card'
-import { getProducts } from '../../data/products'
+import { getCategories, getProducts } from '../../data/products'
 
 export default function Products() {
   const [products, setProducts] = useState([])
+  const [categories, setCategories] = useState([])
   const [isLoading, setIsLoading] = useState(true)
   const [loadingMessage, setLoadingMessage] = useState("Loading products...")
   const [locations, setLocations] = useState([])
+  const [hasActiveFilters, setHasActiveFilters] = useState(false)
 
   useEffect(() => {
-    getProducts().then(data => {
-      if (data) {
+    Promise.all([getProducts(), getCategories()]).then(([productData, categoryData]) => {
+      if (productData) {
 
-        const locationData = [...new Set(data.map(product => product.location))]
+        const locationData = [...new Set(productData.map(product => product.location))]
         const locationObjects = locationData.map(location => ({
           id: location,
           name: location
         }))
 
-        setProducts(data)
+        setProducts(productData)
         setIsLoading(false)
         setLocations(locationObjects)
       }
+
+      if (categoryData) {
+        setCategories(categoryData)
+      }
     })
-    .catch(err => {
-      setLoadingMessage(`Unable to retrieve products. Status code ${err.message} on response.`)
-    })
+      .catch(err => {
+        setLoadingMessage(`Unable to retrieve products. Status code ${err.message} on response.`)
+      })
   }, [])
 
   const searchProducts = (event) => {
+    setHasActiveFilters(!!event)
+
     getProducts(event).then(productsData => {
       if (productsData) {
         setProducts(productsData)
       }
     })
+  }
+
+  const getMostRecentProductsByCategory = (categoryId) => {
+    return products
+      .filter(product => product.category?.id === categoryId)
+      .sort((currentProduct, nextProduct) => {
+        const currentDate = new Date(currentProduct.created_date)
+        const nextDate = new Date(nextProduct.created_date)
+
+        if (nextDate - currentDate !== 0) {
+          return nextDate - currentDate
+        }
+
+        return nextProduct.id - currentProduct.id
+      })
   }
 
   if (isLoading) return <p>{loadingMessage}</p>
@@ -45,11 +68,34 @@ export default function Products() {
     <>
       <Filter productCount={products.length} onSearch={searchProducts} locations={locations} />
 
-      <div className="columns is-multiline">
-        {products.map(product => (
-          <ProductCard product={product} key={product.id} />
-        ))}
-      </div>
+      {
+        hasActiveFilters ?
+          <>
+            <h1 className="title">Products matching filters</h1>
+            <div className="columns is-multiline">
+              {products.map(product => (
+                <ProductCard product={product} key={product.id} />
+              ))}
+            </div>
+          </>
+          :
+          <>
+            {
+              categories.map(category => (
+                <section key={category.id} className="mb-6">
+                  <h1 className="title">{category.name}</h1>
+                  <div className="columns is-multiline">
+                    {
+                      getMostRecentProductsByCategory(category.id).map(product => (
+                        <ProductCard product={product} key={product.id} />
+                      ))
+                    }
+                  </div>
+                </section>
+              ))
+            }
+          </>
+      }
     </>
   )
 }

--- a/pages/products/index.js
+++ b/pages/products/index.js
@@ -60,6 +60,7 @@ export default function Products() {
 
         return nextProduct.id - currentProduct.id
       })
+      .slice(0, 5)
   }
 
   if (isLoading) return <p>{loadingMessage}</p>


### PR DESCRIPTION
Description of PR that completes issue here...

This PR implements product filtering and category display enhancements on the client side. It replaces placeholder category data with real data from the API, enables filtering by category and minimum price, and updates the product list view to group products by category when no filters are applied.

## Changes

- Replace hardcoded category options with data fetched from /productcategories (Tickets 30 & 67)
- Implement category filter dropdown using real backend data (Ticket 30)
- Add support for minimum price filtering in UI (Ticket 31)
- Update product list view to group products by category headers on initial load (Ticket 11)
- Display all products under each category (sorted by most recent) (Ticket 11)
- Hide category grouping and show "Products matching filters" when filters are applied (Ticket 11)
- Ensure frontend sends correct query parameters for filtering (Ticket 31, 12, & 15)

## Testing

Description of how to test code:

- [x] -  Run npm run dev
- [x] -  Navigate to http://localhost:3000/
- [x] -  Open "Filter Products" dropdown
- [x] -  Confirm category dropdown shows:
- [x] - Tools, Auto, Technology, Arts & Crafts, Clothes, Games/Toys
- [x] -  Apply a category filter → verify only matching products display
- [x] -  Apply a minimum price filter → verify only products ≥ value display
- [x] -  Apply a location filter → verify partial matches work (e.g., "York" → New York)
- [x] -  Confirm:
    - No filters → products grouped by category headers
    - Filters applied → single header "Products matching filters"
- [x] -  Verify product counts match API results

## Related Issues

- Fixes 30
- Fixes 67
- Fixes 31
- Fixes 11